### PR TITLE
Relay_Message_Option and Reconfigure_Message_Option updated

### DIFF
--- a/src/DHCPv6_Types.ttcn
+++ b/src/DHCPv6_Types.ttcn
@@ -249,12 +249,12 @@ module DHCPv6_Types{
   
   // rfc 3315 22.10
   type record Relay_Message_Option {
-    LIN2_BO_LAST         code(cg_DHCPv6_OPTION_RELAY_MSG),
-    LIN2_BO_LAST         len,
-    Relay_Message        dhcp_relay_message
+    LIN2_BO_LAST          code(cg_DHCPv6_OPTION_RELAY_MSG),
+    LIN2_BO_LAST          len,
+    Client_Server_Message dhcp_relayed_message
   } with {
     variant "PRESENCE (code = cg_DHCPv6_OPTION_RELAY_MSG)"
-    variant (len) "LENGTHTO (dhcp_relay_message)"
+    variant (len) "LENGTHTO (dhcp_relayed_message)"
   }
   
   // rfc 3315 22.11
@@ -377,7 +377,7 @@ module DHCPv6_Types{
   type record Reconfigure_Message_Option {
     LIN2_BO_LAST      code(cg_DHCPv6_OPTION_RECONF_MSG),
     LIN2_BO_LAST      len (1),
-    INT1              msg_type
+    OCT1              msg_type
   } with {
     variant "PRESENCE (code = cg_DHCPv6_OPTION_RECONF_MSG)"
     variant (len) "LENGTHTO (msg_type)"


### PR DESCRIPTION
Relay_Message_Option must contain relayed Client_Server_Message, otherwise it is endless recursion and not possible to use as DHCPv6 relay.

In Reconfigure_Message_Option it is more convenient to define msg_type as OCT1 to align with other occurences of msg types. Also all msg type constants are defined as OCT1 already so we can avoid multiple oct2int conversions.

Signed-off-by: Jacek Klimkowicz <jakl@semihalf.com>